### PR TITLE
(maint) Bumping Puppet version for dev box to 7.24

### DIFF
--- a/windows/scripts/profile.ps1
+++ b/windows/scripts/profile.ps1
@@ -15,7 +15,7 @@ Function New-LocalGemfile {
     [IO.File]::WriteAllLines($Path, $Gems)
 }
 
-Set-Item -Path Env:\PDK_PUPPET_VERSION -Value '7.16.0'
+Set-Item -Path Env:\PDK_PUPPET_VERSION -Value '7.24.0'
 Set-Item -Path Env:\PATH -Value "$ENV:PATH;C:\Program Files\Git\cmd"
 Import-Module posh-git
 Set-Location -Path $env:userprofile\code


### PR DESCRIPTION
Prior to this commit versions less than 7.24 no longer work.