### PR TITLE
(MAINT) Use latest Puppet 7 version on Windows box

### DIFF
--- a/windows/scripts/profile.ps1
+++ b/windows/scripts/profile.ps1
@@ -15,7 +15,8 @@ Function New-LocalGemfile {
     [IO.File]::WriteAllLines($Path, $Gems)
 }
 
-Set-Item -Path Env:\PDK_PUPPET_VERSION -Value '7.16.0'
+# The following line should be updated so that the PDK_PUPPET_VERSION value matches the latest Puppet version bundled with PDK
+Set-Item -Path Env:\PDK_PUPPET_VERSION -Value '7.28.0'
 Set-Item -Path Env:\PATH -Value "$ENV:PATH;C:\Program Files\Git\cmd"
 Import-Module posh-git
 Set-Location -Path $env:userprofile\code


### PR DESCRIPTION
Prior to this commit, we would sometimes encounter issues when provisioning Windows boxes and performing certain tasks such as PDK command testing. This was due to an outdated version of Puppet 7 being installed in the boxes by default.

This commit aims to address that issue by bumping the installed Puppet 7 version to latest available.