### PR TITLE
(MAINT) Remove pinned Puppet versions from windows

### DIFF
--- a/windows/scripts/profile.ps1
+++ b/windows/scripts/profile.ps1
@@ -15,7 +15,6 @@ Function New-LocalGemfile {
     [IO.File]::WriteAllLines($Path, $Gems)
 }
 
-Set-Item -Path Env:\PDK_PUPPET_VERSION -Value '7.16.0'
 Set-Item -Path Env:\PATH -Value "$ENV:PATH;C:\Program Files\Git\cmd"
 Import-Module posh-git
 Set-Location -Path $env:userprofile\code


### PR DESCRIPTION
Prior to this commit, we would sometimes encounter issues when provisioning Windows boxes and performing certain tasks such as PDK command testing. This was due to an outdated version of Puppet 7 being installed in the boxes by default.

However, recently we realised that the line that pins Puppet to a specific version is no longer needed. This was pointed out by the original author, Craig Gumbley, here: https://github.com/puppetlabs/puppet-dev-boxes/pull/2#issuecomment-1614685180

This commit aims to remove the no longer needed pin to avoid future problems and clean up the code.